### PR TITLE
Fix issue on adding functions as dependencies (issue #8)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
         exclude: >
@@ -56,7 +56,7 @@ repos:
               )$
     -   id: roxygenize
 -   repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.31.1
     hooks:
     -   id: markdownlint
         args: [--fix]

--- a/R/stash.R
+++ b/R/stash.R
@@ -126,7 +126,12 @@ make_hash <- function(vars, env) {
 
   hashes <- c()
   for (var in vars) {
-    hashes <- c(hashes, digest::digest(get(var, envir = env)))
+    obj <- get(var, envir = env)
+    if (is.function(obj) & !is.primitive(obj)) {
+      # For non-primitive functions, replace them with their body before digesting
+      obj <- body(obj)
+    }
+    hashes <- c(hashes, digest::digest(obj))
   }
 
   return(hashes)

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,6 +12,7 @@ knitr::opts_chunk$set(
   out.width = "100%"
 )
 
+devtools::install()
 mustashe::clear_stash()
 ```
 
@@ -29,6 +30,9 @@ The goal of 'mustashe' is to save time on long-running computations by storing a
 The next time the computation is run, instead of evaluating the code, the stashed object is loaded.
 'mustashe' is great for storing intermediate objects in an analysis.
 
+> Note that the CI currently fails because of an issue with how 'mustashe' searches environments for objects and dependencies (Issue [#20](https://github.com/jhrcook/mustashe/issues/20)).
+> The current process works well for standard use, but users may have issues when calling `stash()` within functions.
+
 ## Installation
 
 You can install the released version of 'mustashe' from [CRAN](https://CRAN.R-project.org) with:
@@ -43,6 +47,7 @@ And the development version from [GitHub](https://github.com/jhrcook/mustashe) w
 # install.packages("devtools")
 devtools::install_github("jhrcook/mustashe")
 ```
+
 ## Loading 'mustashe'
 
 The 'mustashe' package is loaded like any other, using the `library()` function.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ time the computation is run, instead of evaluating the code, the stashed
 object is loaded. ‘mustashe’ is great for storing intermediate objects
 in an analysis.
 
+> Note that the CI currently fails because of an issue with how
+> ‘mustashe’ searches environments for objects and dependencies (Issue
+> [\#20](https://github.com/jhrcook/mustashe/issues/20)). The current
+> process works well for standard use, but users may have issues when
+> calling `stash()` within functions.
+
 ## Installation
 
 You can install the released version of ‘mustashe’ from
@@ -67,7 +73,7 @@ stash("rnd_vals", {
 })
 #> Stashing object.
 tictoc::toc()
-#> random simulation: 3.638 sec elapsed
+#> random simulation: 3.378 sec elapsed
 ```
 
 Now, if we come back tomorrow and continue working on the same analysis,
@@ -83,7 +89,7 @@ stash("rnd_vals", {
 })
 #> Loading stashed object.
 tictoc::toc()
-#> random simulation: 0.016 sec elapsed
+#> random simulation: 0.206 sec elapsed
 ```
 
 ## Dependencies

--- a/tests/testthat/test-stash_functions.R
+++ b/tests/testthat/test-stash_functions.R
@@ -1,0 +1,36 @@
+
+test_that("stashing works with function dependencies", {
+
+  f1 <- function(x) { sum(x) }
+  f2 <- sum
+  hash_naive_1 <- digest::digest(f1)
+
+  set.seed(1)
+  result_1 <- stash("stash_func", {sample(letters, 2)},
+                    depends_on = c("f1","f2"), functional=TRUE)
+
+  # Calling the function changes it
+  expect_equal(f1(1:3),6)
+  expect_equal(f2(1:3),6)
+  hash_naive_2 <- digest::digest(f1)
+
+  # This should be loaded, because the body of f1 is not changed
+  result_2 <- stash("stash_func", {sample(letters, 2)},
+                    depends_on = c("f1","f2"), functional=TRUE)
+
+  # If function bodies are correctly hashed, these should be equal
+  expect_equal(result_1, result_2)
+
+  expect_true(hash_naive_1!=hash_naive_2)
+
+  f1 <- function(x) { var(x) }
+
+  # Now the body of f1 IS changed, forcing an update
+  result_3 <- stash("stash_func", {sample(letters, 2)},
+                    depends_on = c("f1","f2"), functional=TRUE)
+
+  # If updating a function body correctly invalidates cache, these should not be equal
+  expect_false(isTRUE(all.equal(result_1, result_3)))
+
+  unstash("stash_func")
+})


### PR DESCRIPTION
This is a proposed fix for issue #8, regarding not being able to use functions as dependencies.

The solution is to check if a given dependency object is a function (and not a primitive function), and if it is, replace the function with its body (using the `body()` function) before computing the digest. Function bodies are not affected by the updated byte code when thee functions are called. Primitive functions need to be excluded from this handling because they do not have function bodies.

The PR also includes a test that fails with the current version of `mustashe`, but passes after the fix*.

(*) The test actually *does not pass* after the fix, if the test is run through the test harness. But that is because of an unrelated issue (issue #20), which concerns the fact that when calling stash within a function, the `depends_on` parameter does not work correctly. If the contents of the test are run directly, in the global environment, it passes after applying the fix.