### PR TITLE
Use appropriate target environement for eval, assignments, and dep-checks

### DIFF
--- a/R/stash.R
+++ b/R/stash.R
@@ -8,7 +8,8 @@
 #' @param code The code to generate the object to be stashed.
 #' @param depends_on A vector of other objects that this one depends on. Changes
 #'   to these objects will cause the re-running of the code, next time.
-#' @param functional If TRUE, return the object rather than setting in the global environment (default FALSE).
+#' @param functional If TRUE, return the object rather than setting in the
+#'   global environment (default FALSE).
 #' @param verbose Whether to print action statements (default TRUE).
 #'
 #' @return Returns \code{NULL} (invisibly).
@@ -40,7 +41,6 @@ stash <- function(var, code, depends_on = NULL, functional = FALSE, verbose = TR
 
   # The environment where all code is evaluated and variables assigned.
   target_env <- parent.frame()
-
   new_hash_tbl <- make_hash_table(formatted_code, depends_on, target_env)
 
   # if the variable has been stashed:
@@ -61,7 +61,9 @@ stash <- function(var, code, depends_on = NULL, functional = FALSE, verbose = TR
       if (verbose) {
         message("Updating stash.")
       }
-      res <- new_stash(var, formatted_code, new_hash_tbl, functional, target_env)
+      res <- new_stash(
+        var, formatted_code, new_hash_tbl, functional, target_env
+      )
     }
   } else {
     if (verbose) {
@@ -131,7 +133,7 @@ make_hash <- function(vars, target_env) {
   for (var in vars) {
     obj <- get(var, envir = target_env)
     if (is.function(obj) & !is.primitive(obj)) {
-      # For non-primitive functions, replace them with their body before digesting
+      # For non-primitive functions, 'digest' the function body.
       obj <- body(obj)
     }
     hashes <- c(hashes, digest::digest(obj))
@@ -192,7 +194,7 @@ load_variable <- function(var, functional, target_env) {
 # Creating a new child environment isolates the code and prevents
 # inadvertent assignment from polluting the target environment.
 evaluate_code <- function(code, target_env) {
-  eval(parse(text = code), envir = new.env(parent=target_env))
+  eval(parse(text = code), envir = new.env(parent = target_env))
 }
 
 
@@ -256,4 +258,3 @@ get_stash_dir <- function() {
   }
   return(stash_dir)
 }
-

--- a/R/stash.R
+++ b/R/stash.R
@@ -38,7 +38,10 @@ stash <- function(var, code, depends_on = NULL, functional = FALSE, verbose = TR
   if (is.null(var)) stop("`var` cannot be NULL")
   if (formatted_code == "NULL") stop("`code` cannot be NULL")
 
-  new_hash_tbl <- make_hash_table(formatted_code, depends_on)
+  # The environment where all code is evaluated and variables assigned.
+  target_env <- parent.frame()
+
+  new_hash_tbl <- make_hash_table(formatted_code, depends_on, target_env)
 
   # if the variable has been stashed:
   #     if the hash tables are equivalent:
@@ -53,32 +56,32 @@ stash <- function(var, code, depends_on = NULL, functional = FALSE, verbose = TR
       if (verbose) {
         message("Loading stashed object.")
       }
-      res <- load_variable(var, functional)
+      res <- load_variable(var, functional, target_env)
     } else {
       if (verbose) {
         message("Updating stash.")
       }
-      res <- new_stash(var, formatted_code, new_hash_tbl, functional)
+      res <- new_stash(var, formatted_code, new_hash_tbl, functional, target_env)
     }
   } else {
     if (verbose) {
       message("Stashing object.")
     }
-    res <- new_stash(var, formatted_code, new_hash_tbl, functional)
+    res <- new_stash(var, formatted_code, new_hash_tbl, functional, target_env)
   }
 
   invisible(res)
 }
 
 # Make a new stash from a variable, code, and hash table.
-new_stash <- function(var, code, hash_tbl, functional) {
-  val <- evaluate_code(code)
+new_stash <- function(var, code, hash_tbl, functional, target_env) {
+  val <- evaluate_code(code, target_env)
   write_hash_table(var, hash_tbl)
   write_val(var, val)
   if (functional) {
     return(val)
   } else {
-    assign_value(var, val)
+    assign_value(var, val, target_env = target_env)
     return(NULL)
   }
 }
@@ -102,10 +105,10 @@ format_code <- function(code) {
 
 
 # Make a hash table for code and any variables in the dependencies.
-make_hash_table <- function(code, depends_on) {
-  code_hash <- make_hash("code", env = environment())
+make_hash_table <- function(code, depends_on, target_env) {
+  code_hash <- make_hash("code", environment())
   depends_on <- sort(depends_on)
-  dependency_hashes <- make_hash(depends_on, .TargetEnv)
+  dependency_hashes <- make_hash(depends_on, target_env)
   tibble::tibble(
     name = c("CODE", depends_on),
     hash = c(code_hash, dependency_hashes)
@@ -114,19 +117,19 @@ make_hash_table <- function(code, depends_on) {
 
 
 # Make hash of an object.
-make_hash <- function(vars, env) {
+make_hash <- function(vars, target_env) {
   if (is.null(vars)) {
     return(NULL)
   }
 
-  missing <- !unlist(lapply(vars, exists, envir = env))
+  missing <- !unlist(lapply(vars, exists, envir = target_env))
   if (any(missing)) {
     stop("Some dependencies are missing from the environment.")
   }
 
   hashes <- c()
   for (var in vars) {
-    obj <- get(var, envir = env)
+    obj <- get(var, envir = target_env)
     if (is.function(obj) & !is.primitive(obj)) {
       # For non-primitive functions, replace them with their body before digesting
       obj <- body(obj)
@@ -172,28 +175,30 @@ write_val <- function(var, val) {
 }
 
 
-# Load in a variable from disk and assign it to the global environment.
-load_variable <- function(var, functional) {
+# Load in a variable from disk and assign it to the target environment.
+load_variable <- function(var, functional, target_env) {
   path <- stash_filename(var)$data_name
   val <- qs::qread(path)
   if (functional) {
     return(val)
   } else {
-    assign_value(var, val)
+    assign_value(var, val, target_env)
     return(NULL)
   }
 }
 
 
-# Evaluate the code in a new environment.
-evaluate_code <- function(code) {
-  eval(parse(text = code), envir = new.env())
+# Evaluate the code in a new child environment of the target environment.
+# Creating a new child environment isolates the code and prevents
+# inadvertent assignment from polluting the target environment.
+evaluate_code <- function(code, target_env) {
+  eval(parse(text = code), envir = new.env(parent=target_env))
 }
 
 
-# Assign the value `val` to the variable `var`.
-assign_value <- function(var, val) {
-  assign(var, val, envir = .TargetEnv)
+# Assign the value `val` to the variable `var` in the target environment.
+assign_value <- function(var, val, target_env) {
+  assign(var, val, envir = target_env)
 }
 
 
@@ -252,7 +257,3 @@ get_stash_dir <- function() {
   return(stash_dir)
 }
 
-# The environment where all code is evaluated and variables assigned.
-# nolint start
-.TargetEnv <- .GlobalEnv
-# nolint end

--- a/man/stash.Rd
+++ b/man/stash.Rd
@@ -14,7 +14,8 @@ stash(var, code, depends_on = NULL, functional = FALSE, verbose = TRUE)
 \item{depends_on}{A vector of other objects that this one depends on. Changes
 to these objects will cause the re-running of the code, next time.}
 
-\item{functional}{If TRUE, return the object rather than setting in the global environment (default FALSE).}
+\item{functional}{If TRUE, return the object rather than setting in the
+global environment (default FALSE).}
 
 \item{verbose}{Whether to print action statements (default TRUE).}
 }

--- a/tests/testthat/test-stash.R
+++ b/tests/testthat/test-stash.R
@@ -39,7 +39,7 @@ test_that("stashing works", {
 
   clear_stash()
 
-  assign("b", 1, envir = .GlobalEnv)
+  b <- 1
   expect_null(stash("a", depends_on = "b", {
     a <- b + 1
   }))
@@ -60,7 +60,7 @@ test_that("stashing works", {
   expect_equal(file_time(file.path(target_dir, "a.qs")), old_qs_time)
   expect_equal(file_time(file.path(target_dir, "a.hash")), old_hash_time)
 
-  assign("b", 2, envir = .GlobalEnv)
+  b <- 2
   expect_null(stash("a", depends_on = "b", {
     a <- b + 1
   }))
@@ -70,7 +70,6 @@ test_that("stashing works", {
 
   # Clean-up
   clear_stash()
-  rm(list = c("a", "b"), envir = .GlobalEnv)
   if (dir.exists(target_dir)) unlink(target_dir, recursive = TRUE)
 })
 

--- a/tests/testthat/test-stash_environment.R
+++ b/tests/testthat/test-stash_environment.R
@@ -1,45 +1,60 @@
-
-
 test_that("expressions are evaluated in correct environment", {
+  verbose <- FALSE
 
-  # Configuration
-  verbose<-FALSE
-
-  # Unstash any old versions of this variable
-  unstash("test_stash_environment", verbose=verbose)
+  # Un-stash any old versions of this variable
+  unstash("test_stash_environment", verbose = verbose)
 
   # Assign the variable in the global environment
-  assign("the_variable", "global", envir=.GlobalEnv)
+  assign("the_variable", "global", envir = .GlobalEnv)
 
-  # Assign the variable in the "outer" (testthat) environment
+  # `the_variable` should be searched for in parent environments, eventually
+  # reaching the global env.
+  result <- stash("test_stash_global_env",
+    {
+      toupper(the_variable)
+    },
+    functional = TRUE,
+    verbose = verbose
+  )
+  unstash("test_stash_global_env")
+  expect_equal(result, "GLOBAL")
+
+  # Assign `the_variable` in the "outer" (testthat) environment
   the_variable <- "outer"
 
-  # the_variable should be retrieved from the scope of the test, not global scope
-  result <- stash("test_stash_environment", {toupper(the_variable)},
-                  functional=TRUE, verbose=verbose)
-  unstash("test_stash_environment", verbose=verbose)
+  # `the_variable` should be retrieved from the scope of the test, not global
+  result <- stash("test_stash_environment",
+    {
+      toupper(the_variable)
+    },
+    functional = TRUE,
+    verbose = verbose
+  )
+  unstash("test_stash_environment", verbose = verbose)
   expect_equal(result, "OUTER")
 
-  # the_variable should be retreived from the scope of the inner function
+  # `the_variable` should be retrieved from the scope of the inner function
   inner_fun <- function() {
     the_variable <- "inner"
     another_inner_variable <- "another inner"
-    stash("test_stash_environment", {toupper(the_variable)},
-                  functional=TRUE, verbose=verbose)
+    stash("test_stash_environment",
+      {
+        toupper(the_variable)
+      },
+      functional = TRUE,
+      verbose = verbose
+    )
   }
   result <- inner_fun()
-  unstash("test_stash_environment", verbose=verbose)
+  unstash("test_stash_environment", verbose = verbose)
   expect_equal(result, "INNER")
-
 })
 
 test_that("dependencies are checked in correct environment", {
+  verbose <- FALSE
 
-  # Configuration
-  verbose<-FALSE
-
-  # Unstash any old versions of this variable
-  unstash("test_stash_environment", verbose=verbose)
+  # Un-stash any old versions of this variable
+  unstash("test_stash_environment", verbose = verbose)
 
   # Assign a dependency variable in the "outer" (testthat) environment
   the_dependency <- "it depends"
@@ -49,51 +64,127 @@ test_that("dependencies are checked in correct environment", {
   set.seed(42)
 
   # Result should be computed
-  result_1 <- stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
-        functional=TRUE, verbose=verbose)
+  result_1 <- stash("test_stash_environment",
+    {
+      sample(100, 1)
+    },
+    depends_on = "the_dependency",
+    functional = TRUE,
+    verbose = verbose
+  )
   expect_equal(result_1, 49)
 
   # Result should be retrieved from stash
-  result_2 <- stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
-        functional=TRUE, verbose=verbose)
+  result_2 <- stash("test_stash_environment",
+    {
+      sample(100, 1)
+    },
+    depends_on = "the_dependency",
+    functional = TRUE,
+    verbose = verbose
+  )
   expect_equal(result_1, 49)
 
-  # Update dependency, should cause restashing
+  # Update dependency, should cause re-stashing
   the_dependency <- "dep in outer environment"
-  result_2 <- stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
-        functional=TRUE, verbose=verbose)
+  result_2 <- stash("test_stash_environment",
+    {
+      sample(100, 1)
+    },
+    depends_on = "the_dependency",
+    functional = TRUE,
+    verbose = verbose
+  )
   expect_equal(result_2, 65)
 
-  # the_dependency should be retreived from the scope of the inner function,
-  # which differs, so a restash should be triggered.
+  # `the_dependency` should be retrieved from the scope of the inner function,
+  # which differs, so a re-stash should be triggered.
   inner_fun <- function() {
     the_dependency <- "dep in inner environment"
-    stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
-        functional=TRUE, verbose=verbose)
+    result <- stash("test_stash_fxn_env",
+      {
+        sample(100, 1)
+      },
+      depends_on = "the_dependency",
+      functional = TRUE,
+      verbose = verbose
+    )
+    return(result)
   }
   result_3 <- inner_fun()
   expect_equal(result_3, 25)
-
 })
+
+test_that(
+  paste(
+    "stashing in a function with a dependency that is an argument",
+    "to the function uses the correct environment"
+  ),
+  {
+    # Setup
+    unstash("x")
+    unstash("y")
+    # Set seed, so sample(100, 1) will return these numbers in order:
+    # 49  65  25  74  18 100  47  24  71  89
+    set.seed(42)
+
+    add_random <- function(x = 100) {
+      stash("y",
+        {
+          y <- x + sample(100, 1)
+        },
+        depends_on = "x"
+      )
+      return(y)
+    }
+
+    # Initial call to run computation with default parameter value.
+    res <- add_random()
+    expect_equal(res, 49 + 100)
+    # Second call to get value from stash.
+    res <- add_random()
+    expect_equal(res, 49 + 100)
+
+    # Initial call to run computation with a new argument object.
+    dep_x <- 4
+    res <- add_random(dep_x)
+    expect_equal(res, 65 + dep_x)
+    # Second call to get value from stash.
+    res <- add_random(dep_x)
+    expect_equal(res, 65 + dep_x)
+
+    # Third call with a new value for the dependency "x".
+    dep_x2 <- 5
+    res <- add_random(dep_x2)
+    expect_equal(res, 25 + dep_x2)
+  }
+)
 
 
 test_that("result is assigned in correct environment", {
+  verbose <- FALSE
 
-  # Configuration
-  verbose<-FALSE
-
-  # Unstash any old versions of this variable.
+  # Un-stash any old versions of this variable.
   # It should not exist, either in the local test environment or .GlobalEnv
-  unstash("test_stash_environment_var", verbose=verbose)
-  expect_false(exists("test_stash_environment_var", environment(), inherits=FALSE))
-  expect_false(exists("test_stash_environment_var", .GlobalEnv, inherits=FALSE))
+  unstash("test_stash_environment_var", verbose = verbose)
+  expect_false(
+    exists("test_stash_environment_var", environment(), inherits = FALSE)
+  )
+  expect_false(
+    exists("test_stash_environment_var", .GlobalEnv, inherits = FALSE)
+  )
 
   # Call stash in non-function mode
-  stash("test_stash_environment_var", {letters[1:3]},
-        verbose=verbose)
+  stash("test_stash_environment_var",
+    {
+      letters[1:3]
+    },
+    verbose = verbose
+  )
 
   # Variable should now exist in local test environment, but not in .GlobalEnv
-  expect_true(exists("test_stash_environment_var", environment(), inherits=FALSE))
+  expect_true(
+    exists("test_stash_environment_var", environment(), inherits = FALSE)
+  )
   rm("test_stash_environment_var")
-
 })

--- a/tests/testthat/test-stash_environment.R
+++ b/tests/testthat/test-stash_environment.R
@@ -1,0 +1,99 @@
+
+
+test_that("expressions are evaluated in correct environment", {
+
+  # Configuration
+  verbose<-FALSE
+
+  # Unstash any old versions of this variable
+  unstash("test_stash_environment", verbose=verbose)
+
+  # Assign the variable in the global environment
+  assign("the_variable", "global", envir=.GlobalEnv)
+
+  # Assign the variable in the "outer" (testthat) environment
+  the_variable <- "outer"
+
+  # the_variable should be retrieved from the scope of the test, not global scope
+  result <- stash("test_stash_environment", {toupper(the_variable)},
+                  functional=TRUE, verbose=verbose)
+  unstash("test_stash_environment", verbose=verbose)
+  expect_equal(result, "OUTER")
+
+  # the_variable should be retreived from the scope of the inner function
+  inner_fun <- function() {
+    the_variable <- "inner"
+    another_inner_variable <- "another inner"
+    stash("test_stash_environment", {toupper(the_variable)},
+                  functional=TRUE, verbose=verbose)
+  }
+  result <- inner_fun()
+  unstash("test_stash_environment", verbose=verbose)
+  expect_equal(result, "INNER")
+
+})
+
+test_that("dependencies are checked in correct environment", {
+
+  # Configuration
+  verbose<-FALSE
+
+  # Unstash any old versions of this variable
+  unstash("test_stash_environment", verbose=verbose)
+
+  # Assign a dependency variable in the "outer" (testthat) environment
+  the_dependency <- "it depends"
+
+  # Set seed, so sample(100, 1) will return these numbers in order:
+  # 49  65  25  74  18 100  47  24  71  89
+  set.seed(42)
+
+  # Result should be computed
+  result_1 <- stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
+        functional=TRUE, verbose=verbose)
+  expect_equal(result_1, 49)
+
+  # Result should be retrieved from stash
+  result_2 <- stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
+        functional=TRUE, verbose=verbose)
+  expect_equal(result_1, 49)
+
+  # Update dependency, should cause restashing
+  the_dependency <- "dep in outer environment"
+  result_2 <- stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
+        functional=TRUE, verbose=verbose)
+  expect_equal(result_2, 65)
+
+  # the_dependency should be retreived from the scope of the inner function,
+  # which differs, so a restash should be triggered.
+  inner_fun <- function() {
+    the_dependency <- "dep in inner environment"
+    stash("test_stash_environment", {sample(100,1)}, depends_on="the_dependency",
+        functional=TRUE, verbose=verbose)
+  }
+  result_3 <- inner_fun()
+  expect_equal(result_3, 25)
+
+})
+
+
+test_that("result is assigned in correct environment", {
+
+  # Configuration
+  verbose<-FALSE
+
+  # Unstash any old versions of this variable.
+  # It should not exist, either in the local test environment or .GlobalEnv
+  unstash("test_stash_environment_var", verbose=verbose)
+  expect_false(exists("test_stash_environment_var", environment(), inherits=FALSE))
+  expect_false(exists("test_stash_environment_var", .GlobalEnv, inherits=FALSE))
+
+  # Call stash in non-function mode
+  stash("test_stash_environment_var", {letters[1:3]},
+        verbose=verbose)
+
+  # Variable should now exist in local test environment, but not in .GlobalEnv
+  expect_true(exists("test_stash_environment_var", environment(), inherits=FALSE))
+  rm("test_stash_environment_var")
+
+})


### PR DESCRIPTION
This PR updates the `stash()` function and underlying private functions to keep track of the appropriate target environment (`target_env`) for evaluating the stashed expression, for assigning the result, and for looking for dependencies.

With this change, `stash()` is no longer dependent on the relevant variables being present in the global environment (`.GlobalEnv`), which makes it easier to use inside other functions.

The PR also adds tests related to this new functionality, and updates some existing tests (which no longer need to make assignments to `.GlobalEnv`).

This PR is proposed as a fix for issue #20.