### PR TITLE
Improved fix to functions as dependencies (#8)

### DIFF
--- a/R/stash.R
+++ b/R/stash.R
@@ -131,8 +131,8 @@ make_hash <- function(vars, target_env) {
   for (var in vars) {
     obj <- get(var, envir = target_env)
     if (is.function(obj) & !is.primitive(obj)) {
-      # For non-primitive functions, replace them with their body before digesting
-      obj <- body(obj)
+      # For functions, deparse before digesting
+      obj <- deparse1(obj)
     }
     hashes <- c(hashes, digest::digest(obj))
   }

--- a/R/stash.R
+++ b/R/stash.R
@@ -132,7 +132,7 @@ make_hash <- function(vars, target_env) {
     obj <- get(var, envir = target_env)
     if (is.function(obj) & !is.primitive(obj)) {
       # For functions, deparse before digesting
-      obj <- deparse1(obj)
+      obj <- deparse(obj)
     }
     hashes <- c(hashes, digest::digest(obj))
   }

--- a/tests/testthat/test-stash_functions.R
+++ b/tests/testthat/test-stash_functions.R
@@ -1,5 +1,41 @@
 
-test_that("stashing works with function dependencies", {
+test_that("function deps are invalidated when updated", {
+
+  # A function is defined by three components:
+  # formals(f), body(f), environment(f)
+  # http://adv-r.had.co.nz/Functions.html
+  # Since the environment of a function is generally not identical across
+  # restarts, it is not feasible to rely on it for determining dependencies.
+  # However, updates to either a functions formals() or body() should trigger a
+  # restash.
+
+  verbose=FALSE
+  unstash("stash_func")
+  set.seed(42)
+
+  # Initial stash for reference
+  f <- function(x,y){x-y}
+  result_1 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+
+  # Changing body SHOULD trigger a restash
+  body(f) <- expression({y-x})
+  result_2 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  expect_true(result_1 != result_2)
+
+  # Changing formals SHOULD trigger a restash
+  formals(f)$y <- 3
+  result_3 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  expect_true(result_2 != result_3)
+
+  # Changing environement SHOULD NOT trigger a restash
+  environment(f) <- new.env()
+  result_4 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  expect_equal(result_3, result_4)
+
+})
+
+
+test_that("function deps are not invalidated by calls", {
   f1 <- function(x) {
     sum(x)
   }

--- a/tests/testthat/test-stash_functions.R
+++ b/tests/testthat/test-stash_functions.R
@@ -9,29 +9,56 @@ test_that("function deps are invalidated when updated", {
   # However, updates to either a functions formals() or body() should trigger a
   # restash.
 
-  verbose=FALSE
+  verbose <- FALSE
   unstash("stash_func")
   set.seed(42)
 
   # Initial stash for reference
-  f <- function(x,y){x-y}
-  result_1 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  f <- function(x, y) {
+    x - y
+  }
+  result_1 <- stash("stash_func",
+    {
+      sample(1000, 1)
+    },
+    depends_on = "f",
+    functional = TRUE
+  )
 
   # Changing body SHOULD trigger a restash
-  body(f) <- expression({y-x})
-  result_2 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  body(f) <- expression({
+    y - x
+  })
+  result_2 <- stash("stash_func",
+    {
+      sample(1000, 1)
+    },
+    depends_on = "f",
+    functional = TRUE
+  )
   expect_true(result_1 != result_2)
 
   # Changing formals SHOULD trigger a restash
   formals(f)$y <- 3
-  result_3 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  result_3 <- stash("stash_func",
+    {
+      sample(1000, 1)
+    },
+    depends_on = "f",
+    functional = TRUE
+  )
   expect_true(result_2 != result_3)
 
   # Changing environement SHOULD NOT trigger a restash
   environment(f) <- new.env()
-  result_4 <- stash("stash_func", {sample(1000,1)}, depends_on="f", functional=TRUE)
+  result_4 <- stash("stash_func",
+    {
+      sample(1000, 1)
+    },
+    depends_on = "f",
+    functional = TRUE
+  )
   expect_equal(result_3, result_4)
-
 })
 
 


### PR DESCRIPTION
This PR is an improved fix for #8.

Thinking about it a bit more, using `body(obj)` before creating digest of functions as dependencies is not the best approach, because it (a) does not reflect changes to the functions `formals()` (arguments) and it contains references to sources that are not clearly stable across restarts and systems. 

(A function is also defined by its `environment()` but the stability of this is also not well defined and so not suitable to determine whether a restash is needed).

Instead, this PR proposes to simply use `deparse1(obj)` to create a string representation of a function before digest, since this is most likely what an average user thinks about when considering whether „a function has changed“.

This PR does depend on PR #22, I'm not sure what you would prefer (in case I submit more of them), making sure to base each PR on what has already been merged, or simply building on my tip and dealing with as it comes up if you want to choose some but not all.